### PR TITLE
WebSocketSession refactor

### DIFF
--- a/client/application/src/commonMain/kotlin/com/thebrownfoxx/neon/client/application/Dependencies.kt
+++ b/client/application/src/commonMain/kotlin/com/thebrownfoxx/neon/client/application/Dependencies.kt
@@ -18,7 +18,6 @@ import com.thebrownfoxx.neon.client.service.offinefirst.OfflineFirstMessenger
 import com.thebrownfoxx.neon.client.websocket.AutoConnectWebSocketSessionProvider
 import com.thebrownfoxx.neon.client.websocket.AutoRetryWebSocketRequester
 import com.thebrownfoxx.neon.client.websocket.AutoRetryWebSocketSubscriber
-import com.thebrownfoxx.neon.common.PrintLogger
 import com.thebrownfoxx.outcome.Success
 import io.ktor.client.HttpClient
 import kotlinx.coroutines.CoroutineScope
@@ -34,7 +33,6 @@ class AppDependencies(
     private val database: Database,
     externalScope: CoroutineScope,
 ) : Dependencies {
-    override val logger = PrintLogger
 
     private val tokenRepository = ExposedTokenRepository(database, externalScope)
 
@@ -47,7 +45,6 @@ class AppDependencies(
     private val webSocketConnector = KtorClientWebSocketConnector(
         httpClient = httpClient,
         externalScope = externalScope,
-        logger = logger,
     )
 
     private val token = tokenRepository.getAsFlow().transform { token ->
@@ -57,7 +54,6 @@ class AppDependencies(
     private val webSocketSessionProvider = AutoConnectWebSocketSessionProvider(
         token = token,
         connector = webSocketConnector,
-        logger = logger,
         externalScope = externalScope,
     )
 
@@ -109,7 +105,6 @@ class AppDependencies(
             remoteMessenger = remoteMessenger,
             localMessageRepository = localMessageRepository,
             externalScope = externalScope,
-            logger = logger,
         )
     }
 }

--- a/client/application/src/commonMain/kotlin/com/thebrownfoxx/neon/client/application/dummy/DummyDependencies.kt
+++ b/client/application/src/commonMain/kotlin/com/thebrownfoxx/neon/client/application/dummy/DummyDependencies.kt
@@ -1,12 +1,10 @@
 package com.thebrownfoxx.neon.client.application.dummy
 
 import com.thebrownfoxx.neon.client.service.Dependencies
-import com.thebrownfoxx.neon.common.PrintLogger
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 class DummyDependencies : Dependencies {
-    override val logger = PrintLogger
     override val authenticator = DummyAuthenticator()
     override val groupManager = DummyGroupManager(getGroupDelay = 100.milliseconds)
     override val memberManager = DummyMemberManager()

--- a/client/application/src/commonMain/kotlin/com/thebrownfoxx/neon/client/application/ui/navigation/ChatNavigation.kt
+++ b/client/application/src/commonMain/kotlin/com/thebrownfoxx/neon/client/application/ui/navigation/ChatNavigation.kt
@@ -21,7 +21,7 @@ data object ChatRoute
 fun NavGraphBuilder.chatDestination() = composable<ChatRoute> {
     val viewModel = viewModel {
         with(dependencies) {
-            ChatViewModel(authenticator, groupManager, memberManager, messenger, logger)
+            ChatViewModel(authenticator, groupManager, memberManager, messenger)
         }
     }
     with(viewModel) {

--- a/client/application/src/commonMain/kotlin/com/thebrownfoxx/neon/client/application/ui/screen/chat/ChatViewModel.kt
+++ b/client/application/src/commonMain/kotlin/com/thebrownfoxx/neon/client/application/ui/screen/chat/ChatViewModel.kt
@@ -10,7 +10,6 @@ import com.thebrownfoxx.neon.client.service.Authenticator
 import com.thebrownfoxx.neon.client.service.GroupManager
 import com.thebrownfoxx.neon.client.service.MemberManager
 import com.thebrownfoxx.neon.client.service.Messenger
-import com.thebrownfoxx.neon.common.Logger
 import com.thebrownfoxx.neon.common.type.id.GroupId
 import com.thebrownfoxx.neon.common.type.id.MessageId
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -22,7 +21,6 @@ class ChatViewModel(
     groupManager: GroupManager,
     memberManager: MemberManager,
     private val messenger: Messenger,
-    logger: Logger,
 ) : ViewModel() {
     private val chatPreviewIdMap = mutableMapOf<GroupId, ChatPreviewStateId>()
 
@@ -38,7 +36,6 @@ class ChatViewModel(
         idMap = chatPreviewIdMap,
         lastVisibleGroupId = lastVisibleGroupId.asStateFlow(),
         externalScope = viewModelScope,
-        logger = logger,
     )
 
     private val messageIdMap = mutableMapOf<MessageId, MessageListEntryId>()
@@ -57,7 +54,6 @@ class ChatViewModel(
         lastVisibleMessageId = lastVisibleMessageId.asStateFlow(),
         message = message,
         externalScope = viewModelScope,
-        logger = logger,
     )
 
     val chatPreviewsState = chatPreviewsStateHandler.previews

--- a/client/application/src/commonMain/kotlin/com/thebrownfoxx/neon/client/application/ui/screen/chat/conversation/ConversationStateHandler.kt
+++ b/client/application/src/commonMain/kotlin/com/thebrownfoxx/neon/client/application/ui/screen/chat/conversation/ConversationStateHandler.kt
@@ -26,7 +26,6 @@ import com.thebrownfoxx.neon.client.service.Authenticator
 import com.thebrownfoxx.neon.client.service.GroupManager
 import com.thebrownfoxx.neon.client.service.MemberManager
 import com.thebrownfoxx.neon.client.service.Messenger
-import com.thebrownfoxx.neon.common.Logger
 import com.thebrownfoxx.neon.common.data.SingleCache
 import com.thebrownfoxx.neon.common.data.SingleJobManager
 import com.thebrownfoxx.neon.common.extension.coercedSubList
@@ -34,6 +33,7 @@ import com.thebrownfoxx.neon.common.extension.flow.combineOrEmpty
 import com.thebrownfoxx.neon.common.extension.flow.flow
 import com.thebrownfoxx.neon.common.extension.flow.mirror
 import com.thebrownfoxx.neon.common.extension.toLocalDateTime
+import com.thebrownfoxx.neon.common.logError
 import com.thebrownfoxx.neon.common.type.Loadable
 import com.thebrownfoxx.neon.common.type.Loaded
 import com.thebrownfoxx.neon.common.type.Loading
@@ -65,7 +65,6 @@ class ConversationStateHandler(
     lastVisibleMessageId: Flow<MessageId?>,
     message: Flow<String>,
     externalScope: CoroutineScope,
-    private val logger: Logger,
 ) {
     private val infoMirrorJobManager = SingleJobManager(externalScope)
     private val infoCache = SingleCache<Loadable<ConversationInfoState>>(externalScope)
@@ -102,7 +101,7 @@ class ConversationStateHandler(
             message = message,
         )
     }
-        .catch { logger.logError(it) }
+        .catch { logError(it) }
         .stateIn(externalScope, SharingStarted.Eagerly, null)
 
     private fun getConversation(

--- a/client/application/src/commonMain/kotlin/com/thebrownfoxx/neon/client/application/ui/screen/chat/previews/ChatPreviewsStateHandler.kt
+++ b/client/application/src/commonMain/kotlin/com/thebrownfoxx/neon/client/application/ui/screen/chat/previews/ChatPreviewsStateHandler.kt
@@ -26,7 +26,6 @@ import com.thebrownfoxx.neon.client.service.Authenticator
 import com.thebrownfoxx.neon.client.service.GroupManager
 import com.thebrownfoxx.neon.client.service.MemberManager
 import com.thebrownfoxx.neon.client.service.Messenger
-import com.thebrownfoxx.neon.common.Logger
 import com.thebrownfoxx.neon.common.data.Cache
 import com.thebrownfoxx.neon.common.data.JobManager
 import com.thebrownfoxx.neon.common.extension.flatListOf
@@ -34,6 +33,7 @@ import com.thebrownfoxx.neon.common.extension.flow.combineOrEmpty
 import com.thebrownfoxx.neon.common.extension.flow.flow
 import com.thebrownfoxx.neon.common.extension.flow.mirror
 import com.thebrownfoxx.neon.common.extension.toLocalDateTime
+import com.thebrownfoxx.neon.common.logError
 import com.thebrownfoxx.neon.common.type.Loadable
 import com.thebrownfoxx.neon.common.type.Loaded
 import com.thebrownfoxx.neon.common.type.Loading
@@ -60,7 +60,6 @@ class ChatPreviewsStateHandler(
     private val idMap: MutableMap<GroupId, ChatPreviewStateId>,
     lastVisibleGroupId: Flow<GroupId?>,
     externalScope: CoroutineScope,
-    private val logger: Logger,
 ) {
     private val previewValuesMirrorJobManager = JobManager<GroupId>(externalScope)
     private val previewValuesCache = Cache<GroupId, Loadable<ChatPreviewStateValues>>(externalScope)
@@ -77,7 +76,7 @@ class ChatPreviewsStateHandler(
             getPreviews(loggedInMemberId, lastVisiblePreviewId)
         }
     }
-        .catch { logger.logError(it) }
+        .catch { logError(it) }
         .stateIn(externalScope, SharingStarted.Eagerly, initialState)
 
     private fun getPreviews(

--- a/client/service/default/src/commonMain/kotlin/com/thebrownfoxx/neon/client/service/default/KtorClientWebSocketConnector.kt
+++ b/client/service/default/src/commonMain/kotlin/com/thebrownfoxx/neon/client/service/default/KtorClientWebSocketConnector.kt
@@ -2,7 +2,6 @@ package com.thebrownfoxx.neon.client.service.default
 
 import com.thebrownfoxx.neon.client.websocket.WebSocketConnectionError
 import com.thebrownfoxx.neon.client.websocket.WebSocketConnector
-import com.thebrownfoxx.neon.common.Logger
 import com.thebrownfoxx.neon.common.type.Jwt
 import com.thebrownfoxx.outcome.Outcome
 import com.thebrownfoxx.outcome.map.mapError
@@ -16,7 +15,6 @@ import kotlinx.coroutines.CoroutineScope
 class KtorClientWebSocketConnector(
     private val httpClient: HttpClient,
     private val externalScope: CoroutineScope,
-    private val logger: Logger,
 ) : WebSocketConnector {
     override suspend fun connect(
         token: Jwt,
@@ -29,7 +27,7 @@ class KtorClientWebSocketConnector(
             ) {
                 bearerAuth(token.value)
             }
-            KtorClientWebSocketSession(actualSession, logger, externalScope)
+            KtorClientWebSocketSession(actualSession, externalScope)
         }.mapError { error ->
             when (error) {
                 is WebSocketException -> WebSocketConnectionError.Unauthorized

--- a/client/service/default/src/commonMain/kotlin/com/thebrownfoxx/neon/client/service/default/KtorClientWebSocketConnector.kt
+++ b/client/service/default/src/commonMain/kotlin/com/thebrownfoxx/neon/client/service/default/KtorClientWebSocketConnector.kt
@@ -1,6 +1,5 @@
 package com.thebrownfoxx.neon.client.service.default
 
-import com.thebrownfoxx.neon.client.websocket.KtorClientWebSocketSession
 import com.thebrownfoxx.neon.client.websocket.WebSocketConnectionError
 import com.thebrownfoxx.neon.client.websocket.WebSocketConnector
 import com.thebrownfoxx.neon.common.Logger

--- a/client/service/default/src/commonMain/kotlin/com/thebrownfoxx/neon/client/service/default/KtorClientWebSocketSession.kt
+++ b/client/service/default/src/commonMain/kotlin/com/thebrownfoxx/neon/client/service/default/KtorClientWebSocketSession.kt
@@ -9,6 +9,7 @@ import com.thebrownfoxx.neon.common.extension.loop
 import com.thebrownfoxx.neon.common.logInfo
 import com.thebrownfoxx.neon.common.type.Type
 import com.thebrownfoxx.outcome.Outcome
+import com.thebrownfoxx.outcome.map.getOrElse
 import com.thebrownfoxx.outcome.map.mapError
 import com.thebrownfoxx.outcome.map.onFailure
 import com.thebrownfoxx.outcome.map.onSuccess
@@ -32,9 +33,7 @@ class KtorClientWebSocketSession(
 ) : WebSocketSession {
     init {
         externalScope.launch {
-            loop {
-                receiveMessages(onFailure = ::breakLoop)
-            }
+            loop { receiveMessages(onFailure = ::breakLoop) }
         }
     }
 
@@ -51,7 +50,7 @@ class KtorClientWebSocketSession(
             }
         }
             .mapError { SendError }
-            .onSuccess { logInfo("SENT: $message") }
+            .onSuccess { logInfo("WS SENT: $message") }
     }
 
     override suspend fun close() {
@@ -63,7 +62,8 @@ class KtorClientWebSocketSession(
             .onSuccess { frame ->
                 val message = KtorSerializedWebSocketMessage(session.converter!!, frame)
                 _incomingMessages.emit(message)
-                logInfo("RECEIVED: $message")
+                val serializedValue = message.serializedValue.getOrElse { "<unknown message>" }
+                logInfo("WS RECEIVED: $serializedValue")
             }.onFailure {
                 _closed.value = true
                 onFailure()

--- a/client/service/default/src/commonMain/kotlin/com/thebrownfoxx/neon/client/service/default/KtorClientWebSocketSession.kt
+++ b/client/service/default/src/commonMain/kotlin/com/thebrownfoxx/neon/client/service/default/KtorClientWebSocketSession.kt
@@ -1,12 +1,12 @@
 package com.thebrownfoxx.neon.client.service.default
 
-import com.thebrownfoxx.neon.common.Logger
 import com.thebrownfoxx.neon.common.data.websocket.WebSocketSession
 import com.thebrownfoxx.neon.common.data.websocket.WebSocketSession.SendError
 import com.thebrownfoxx.neon.common.data.websocket.ktor.KtorSerializedWebSocketMessage
 import com.thebrownfoxx.neon.common.data.websocket.ktor.toKtorTypeInfo
 import com.thebrownfoxx.neon.common.data.websocket.model.SerializedWebSocketMessage
 import com.thebrownfoxx.neon.common.extension.loop
+import com.thebrownfoxx.neon.common.logInfo
 import com.thebrownfoxx.neon.common.type.Type
 import com.thebrownfoxx.outcome.Outcome
 import com.thebrownfoxx.outcome.map.mapError
@@ -28,41 +28,45 @@ import kotlinx.coroutines.withContext
 
 class KtorClientWebSocketSession(
     private val session: DefaultClientWebSocketSession,
-    private val logger: Logger,
     externalScope: CoroutineScope,
 ) : WebSocketSession {
     init {
         externalScope.launch {
             loop {
-                runFailing { session.incoming.receive() }
-                    .onSuccess { frame ->
-                        val message = KtorSerializedWebSocketMessage(session.converter!!, frame)
-                        _incomingMessages.emit(message)
-                    }.onFailure {
-                        _closed.value = true
-                        breakLoop()
-                    }
+                receiveMessages(onFailure = ::breakLoop)
             }
         }
     }
 
     private val _closed = MutableStateFlow(false)
+
     override val closed = _closed.asStateFlow()
-
     private val _incomingMessages = MutableSharedFlow<SerializedWebSocketMessage>()
-    override val incomingMessages = _incomingMessages.asSharedFlow()
 
+    override val incomingMessages = _incomingMessages.asSharedFlow()
     override suspend fun send(message: Any?, type: Type): Outcome<Unit, SendError> {
         return runFailing {
             withContext(Dispatchers.IO) {
                 session.sendSerialized(message, type.toKtorTypeInfo())
             }
-        }.mapError { SendError }.onSuccess {
-            logger.logInfo("SENT: $message")
         }
+            .mapError { SendError }
+            .onSuccess { logInfo("SENT: $message") }
     }
 
     override suspend fun close() {
         session.close()
+    }
+
+    private suspend fun receiveMessages(onFailure: () -> Unit) {
+        runFailing { session.incoming.receive() }
+            .onSuccess { frame ->
+                val message = KtorSerializedWebSocketMessage(session.converter!!, frame)
+                _incomingMessages.emit(message)
+                logInfo("RECEIVED: $message")
+            }.onFailure {
+                _closed.value = true
+                onFailure()
+            }
     }
 }

--- a/client/service/default/src/commonMain/kotlin/com/thebrownfoxx/neon/client/service/default/KtorClientWebSocketSession.kt
+++ b/client/service/default/src/commonMain/kotlin/com/thebrownfoxx/neon/client/service/default/KtorClientWebSocketSession.kt
@@ -1,4 +1,4 @@
-package com.thebrownfoxx.neon.client.websocket
+package com.thebrownfoxx.neon.client.service.default
 
 import com.thebrownfoxx.neon.common.Logger
 import com.thebrownfoxx.neon.common.data.websocket.WebSocketSession

--- a/client/service/src/commonMain/kotlin/com/thebrownfoxx/neon/client/service/Dependencies.kt
+++ b/client/service/src/commonMain/kotlin/com/thebrownfoxx/neon/client/service/Dependencies.kt
@@ -1,9 +1,6 @@
 package com.thebrownfoxx.neon.client.service
 
-import com.thebrownfoxx.neon.common.Logger
-
 interface Dependencies {
-    val logger: Logger
     val authenticator: Authenticator
     val groupManager: GroupManager
     val memberManager: MemberManager

--- a/client/websocket/src/commonMain/kotlin/com/thebrownfoxx/neon/client/websocket/AlwaysActiveWebSocketSession.kt
+++ b/client/websocket/src/commonMain/kotlin/com/thebrownfoxx/neon/client/websocket/AlwaysActiveWebSocketSession.kt
@@ -190,7 +190,7 @@ class AlwaysActiveWebSocketSession : WebSocketSession, WebSocketSubscriber, WebS
     private suspend fun WebSocketSession.mirrorIncomingMessages() {
         _incomingMessages.mirror(incomingMessages) {
             val label = it.serializedValue.getOrNull() ?: "<unknown message>"
-            logInfo("Received: $label")
+            logInfo("WS RECEIVED: $label")
             it
         }
     }
@@ -206,7 +206,7 @@ class AlwaysActiveWebSocketSession : WebSocketSession, WebSocketSubscriber, WebS
             )
             loop {
                 send(message.value, message.type).onSuccess {
-                    logInfo("Sent: ${message.value}")
+                    logInfo("WS SENT: ${message.value}")
                     breakLoop()
                 }
                 exponentialBackoff.delay()

--- a/client/websocket/src/commonMain/kotlin/com/thebrownfoxx/neon/client/websocket/AlwaysActiveWebSocketSession.kt
+++ b/client/websocket/src/commonMain/kotlin/com/thebrownfoxx/neon/client/websocket/AlwaysActiveWebSocketSession.kt
@@ -39,6 +39,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.yield
 import kotlin.time.Duration.Companion.seconds
 
+@Deprecated("Use a WebSocketSessionProvider instead")
 class AlwaysActiveWebSocketSession(
     private val logger: Logger,
 ) : WebSocketSession, WebSocketSubscriber, WebSocketRequester {

--- a/client/websocket/src/commonMain/kotlin/com/thebrownfoxx/neon/client/websocket/AutoConnectWebSocketSessionProvider.kt
+++ b/client/websocket/src/commonMain/kotlin/com/thebrownfoxx/neon/client/websocket/AutoConnectWebSocketSessionProvider.kt
@@ -1,11 +1,12 @@
 package com.thebrownfoxx.neon.client.websocket
 
-import com.thebrownfoxx.neon.common.Logger
 import com.thebrownfoxx.neon.common.data.websocket.WebSocketSession
 import com.thebrownfoxx.neon.common.data.websocket.awaitClose
 import com.thebrownfoxx.neon.common.extension.ExponentialBackoff
 import com.thebrownfoxx.neon.common.extension.ExponentialBackoffValues
 import com.thebrownfoxx.neon.common.extension.loop
+import com.thebrownfoxx.neon.common.logError
+import com.thebrownfoxx.neon.common.logInfo
 import com.thebrownfoxx.neon.common.type.Jwt
 import com.thebrownfoxx.outcome.Outcome
 import com.thebrownfoxx.outcome.map.onFailure
@@ -20,7 +21,6 @@ import kotlin.time.Duration.Companion.seconds
 class AutoConnectWebSocketSessionProvider(
     private val token: Flow<Jwt>,
     private val connector: WebSocketConnector,
-    private val logger: Logger,
     externalScope: CoroutineScope,
 ) : WebSocketSessionProvider {
     private val exponentialBackoffValues = ExponentialBackoffValues(
@@ -63,15 +63,15 @@ class AutoConnectWebSocketSessionProvider(
         log: String,
         onUnauthorized: () -> Unit,
     ) {
-        logger.logError("WebSocket connection failed. $log")
+        logError("WebSocket connection failed. $log")
         when (error) {
             WebSocketConnectionError.Unauthorized -> {
-                logger.logError("WebSocket reconnection canceled")
+                logError("WebSocket reconnection canceled")
                 onUnauthorized()
             }
 
             WebSocketConnectionError.ConnectionError ->
-                logger.logError("Reconnecting WebSocket")
+                logError("Reconnecting WebSocket")
         }
     }
 
@@ -79,10 +79,10 @@ class AutoConnectWebSocketSessionProvider(
         session: WebSocketSession,
         exponentialBackoff: ExponentialBackoff,
     ) {
-        logger.logInfo("WebSocket connected")
+        logInfo("WebSocket connected")
         _session.value = session
         exponentialBackoff.reset()
         session.awaitClose()
-        logger.logInfo("WebSocket finished. Reconnecting...")
+        logInfo("WebSocket finished. Reconnecting...")
     }
 }

--- a/client/websocket/src/commonMain/kotlin/com/thebrownfoxx/neon/client/websocket/AutoConnectWebSocketSessionProvider.kt
+++ b/client/websocket/src/commonMain/kotlin/com/thebrownfoxx/neon/client/websocket/AutoConnectWebSocketSessionProvider.kt
@@ -1,0 +1,88 @@
+package com.thebrownfoxx.neon.client.websocket
+
+import com.thebrownfoxx.neon.common.Logger
+import com.thebrownfoxx.neon.common.data.websocket.WebSocketSession
+import com.thebrownfoxx.neon.common.data.websocket.awaitClose
+import com.thebrownfoxx.neon.common.extension.ExponentialBackoff
+import com.thebrownfoxx.neon.common.extension.ExponentialBackoffValues
+import com.thebrownfoxx.neon.common.extension.loop
+import com.thebrownfoxx.neon.common.type.Jwt
+import com.thebrownfoxx.outcome.Outcome
+import com.thebrownfoxx.outcome.map.onFailure
+import com.thebrownfoxx.outcome.map.onSuccess
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.seconds
+
+class AutoConnectWebSocketSessionProvider(
+    private val token: Flow<Jwt>,
+    private val connector: WebSocketConnector,
+    private val logger: Logger,
+    externalScope: CoroutineScope,
+) : WebSocketSessionProvider {
+    private val exponentialBackoffValues = ExponentialBackoffValues(
+        initialDelay = 1.seconds,
+        maxDelay = 32.seconds,
+        factor = 2.0,
+    )
+
+    private val _session = MutableStateFlow<WebSocketSession?>(null)
+    override val session = _session.filterNotNull()
+
+    init {
+        externalScope.launch {
+            token.collect { token ->
+                connect(token)
+            }
+        }
+    }
+
+    private suspend fun connect(token: Jwt) {
+        initializeSession {
+            connector.connect(token)
+        }
+    }
+
+    private suspend fun initializeSession(
+        initialize: suspend () -> Outcome<WebSocketSession, WebSocketConnectionError>,
+    ) {
+        val exponentialBackoff = ExponentialBackoff(exponentialBackoffValues)
+        loop {
+            initialize()
+                .onFailure { onConnectionFailure(it, log, onUnauthorized = { breakLoop() }) }
+                .onSuccess { onConnectionSuccess(it, exponentialBackoff) }
+            exponentialBackoff.delay()
+        }
+    }
+
+    private fun onConnectionFailure(
+        error: WebSocketConnectionError,
+        log: String,
+        onUnauthorized: () -> Unit,
+    ) {
+        logger.logError("WebSocket connection failed. $log")
+        when (error) {
+            WebSocketConnectionError.Unauthorized -> {
+                logger.logError("WebSocket reconnection canceled")
+                onUnauthorized()
+            }
+
+            WebSocketConnectionError.ConnectionError ->
+                logger.logError("Reconnecting WebSocket")
+        }
+    }
+
+    private suspend fun onConnectionSuccess(
+        session: WebSocketSession,
+        exponentialBackoff: ExponentialBackoff,
+    ) {
+        logger.logInfo("WebSocket connected")
+        _session.value = session
+        exponentialBackoff.reset()
+        session.awaitClose()
+        logger.logInfo("WebSocket finished. Reconnecting...")
+    }
+}

--- a/client/websocket/src/commonMain/kotlin/com/thebrownfoxx/neon/client/websocket/AutoRetryWebSocketRequester.kt
+++ b/client/websocket/src/commonMain/kotlin/com/thebrownfoxx/neon/client/websocket/AutoRetryWebSocketRequester.kt
@@ -1,0 +1,46 @@
+package com.thebrownfoxx.neon.client.websocket
+
+import com.thebrownfoxx.neon.client.websocket.WebSocketRequester.RequestTimeout
+import com.thebrownfoxx.neon.common.data.websocket.model.WebSocketMessage
+import com.thebrownfoxx.neon.common.extension.supervisorScope
+import com.thebrownfoxx.neon.common.extension.withTimeout
+import com.thebrownfoxx.neon.common.type.Type
+import com.thebrownfoxx.outcome.Failure
+import com.thebrownfoxx.outcome.Outcome
+import com.thebrownfoxx.outcome.Success
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+class AutoRetryWebSocketRequester(
+    private val webSocketSessionProvider: WebSocketSessionProvider,
+    private val requestTimeout: Duration = 5.seconds,
+) : WebSocketRequester {
+
+    override suspend fun <R> request(
+        request: WebSocketMessage?,
+        requestType: Type,
+        handleResponse: RequestHandler<R>.() -> Unit,
+    ): Outcome<R, RequestTimeout> {
+        val session = webSocketSessionProvider.session.filterNotNull().first()
+        var response: R? = null
+        supervisorScope {
+            val requestHandler = RequestHandler.create(
+                webSocketSession = session,
+                externalScope = this,
+                handleResponse = handleResponse,
+            )
+            session.send(request, requestType)
+            withTimeout(requestTimeout) {
+                response = requestHandler.await()
+            }
+            cancel()
+        }
+        return when (val finalResponse = response) {
+            null -> Failure(RequestTimeout)
+            else -> Success(finalResponse)
+        }
+    }
+}

--- a/client/websocket/src/commonMain/kotlin/com/thebrownfoxx/neon/client/websocket/AutoRetryWebSocketSubscriber.kt
+++ b/client/websocket/src/commonMain/kotlin/com/thebrownfoxx/neon/client/websocket/AutoRetryWebSocketSubscriber.kt
@@ -1,0 +1,78 @@
+package com.thebrownfoxx.neon.client.websocket
+
+import com.thebrownfoxx.neon.common.data.websocket.WebSocketSession
+import com.thebrownfoxx.neon.common.data.websocket.awaitClose
+import com.thebrownfoxx.neon.common.data.websocket.model.WebSocketMessage
+import com.thebrownfoxx.neon.common.extension.ExponentialBackoff
+import com.thebrownfoxx.neon.common.extension.ExponentialBackoffValues
+import com.thebrownfoxx.neon.common.extension.flow.channelFlow
+import com.thebrownfoxx.neon.common.extension.flow.mirror
+import com.thebrownfoxx.neon.common.type.Type
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.seconds
+
+class AutoRetryWebSocketSubscriber(
+    private val webSocketSessionProvider: WebSocketSessionProvider,
+    private val exponentialBackoffValues: ExponentialBackoffValues =
+        defaultExponentialBackoffValues,
+) : WebSocketSubscriber {
+    companion object {
+        private val defaultExponentialBackoffValues = ExponentialBackoffValues(
+            initialDelay = 5.seconds,
+            maxDelay = 32.seconds,
+            factor = 2.0,
+        )
+    }
+
+    override fun <R> subscribeAsFlow(
+        request: WebSocketMessage?,
+        requestType: Type,
+        handleResponse: SubscriptionHandler<R>.() -> Unit,
+    ): Flow<R> {
+        return channelFlow {
+            webSocketSessionProvider.session.collectLatest { session ->
+                val responseExponentialBackoff = ExponentialBackoff(exponentialBackoffValues)
+                while (true) {
+                    subscribe(
+                        scope = this,
+                        request = request,
+                        session = session,
+                        handleResponse = handleResponse,
+                        requestType = requestType,
+                        responseExponentialBackoff = responseExponentialBackoff,
+                    )
+                }
+            }
+        }
+    }
+
+    private suspend fun <R> FlowCollector<R>.subscribe(
+        scope: CoroutineScope,
+        request: WebSocketMessage?,
+        session: WebSocketSession,
+        handleResponse: SubscriptionHandler<R>.() -> Unit,
+        requestType: Type,
+        responseExponentialBackoff: ExponentialBackoff,
+    ) {
+        val subscriptionHandler = SubscriptionHandler.create(
+            requestId = request?.requestId,
+            session = session,
+            externalScope = scope,
+            handleResponse = handleResponse,
+        )
+        val mirrorJob = scope.launch { mirror(subscriptionHandler.response) }
+        if (request != null) session.send(request, requestType)
+        responseExponentialBackoff.withTimeout {
+            subscriptionHandler.awaitFirst()
+            runAfterTimeout {
+                responseExponentialBackoff.reset()
+                session.awaitClose()
+            }
+        }
+        mirrorJob.cancel()
+    }
+}

--- a/client/websocket/src/commonMain/kotlin/com/thebrownfoxx/neon/client/websocket/WebSocketConnector.kt
+++ b/client/websocket/src/commonMain/kotlin/com/thebrownfoxx/neon/client/websocket/WebSocketConnector.kt
@@ -1,8 +1,9 @@
 package com.thebrownfoxx.neon.client.websocket
 
+import com.thebrownfoxx.neon.common.data.websocket.WebSocketSession
 import com.thebrownfoxx.neon.common.type.Jwt
 import com.thebrownfoxx.outcome.Outcome
 
 interface WebSocketConnector {
-    suspend fun connect(token: Jwt): Outcome<KtorClientWebSocketSession, WebSocketConnectionError>
+    suspend fun connect(token: Jwt): Outcome<WebSocketSession, WebSocketConnectionError>
 }

--- a/client/websocket/src/commonMain/kotlin/com/thebrownfoxx/neon/client/websocket/WebSocketSessionProvider.kt
+++ b/client/websocket/src/commonMain/kotlin/com/thebrownfoxx/neon/client/websocket/WebSocketSessionProvider.kt
@@ -1,0 +1,8 @@
+package com.thebrownfoxx.neon.client.websocket
+
+import com.thebrownfoxx.neon.common.data.websocket.WebSocketSession
+import kotlinx.coroutines.flow.Flow
+
+interface WebSocketSessionProvider {
+    val session: Flow<WebSocketSession>
+}

--- a/client/websocket/src/commonMain/kotlin/com/thebrownfoxx/neon/client/websocket/WebSocketSubscriber.kt
+++ b/client/websocket/src/commonMain/kotlin/com/thebrownfoxx/neon/client/websocket/WebSocketSubscriber.kt
@@ -46,7 +46,7 @@ class SubscriptionHandler<R> private constructor(
     }
 
     @PublishedApi
-    internal val mutableResponse = MutableSharedFlow<R>()
+    internal val mutableResponse = MutableSharedFlow<R>(extraBufferCapacity = 16)
     val response = mutableResponse.asSharedFlow()
 
     @PublishedApi

--- a/common/src/commonMain/kotlin/com/thebrownfoxx/neon/common/Logger.kt
+++ b/common/src/commonMain/kotlin/com/thebrownfoxx/neon/common/Logger.kt
@@ -1,11 +1,28 @@
 package com.thebrownfoxx.neon.common
 
 import com.thebrownfoxx.outcome.StackTrace
+import com.thebrownfoxx.outcome.map.FailureMapScope
 
 interface Logger {
     fun logInfo(message: Any?, stackTrace: StackTrace = StackTrace())
     fun logError(message: Any?, stackTrace: StackTrace = StackTrace())
     fun logDebug(message: Any?, stackTrace: StackTrace = StackTrace())
+}
+
+object LoggerProvider {
+    var logger: Logger = PrintLogger
+}
+
+fun logInfo(message: Any?, stackTrace: StackTrace = StackTrace()) {
+    LoggerProvider.logger.logInfo(message, stackTrace)
+}
+
+fun logError(message: Any?, stackTrace: StackTrace = StackTrace()) {
+    LoggerProvider.logger.logError(message, stackTrace)
+}
+
+fun logDebug(message: Any?, stackTrace: StackTrace = StackTrace()) {
+    LoggerProvider.logger.logDebug(message, stackTrace)
 }
 
 object PrintLogger : Logger {
@@ -20,4 +37,8 @@ object PrintLogger : Logger {
     override fun logDebug(message: Any?, stackTrace: StackTrace) {
         println("DEBUG: $message ${stackTrace.label}")
     }
+}
+
+fun FailureMapScope.logError() {
+    logError(log)
 }

--- a/common/src/commonMain/kotlin/com/thebrownfoxx/neon/common/extension/flow/FilterSuccess.kt
+++ b/common/src/commonMain/kotlin/com/thebrownfoxx/neon/common/extension/flow/FilterSuccess.kt
@@ -1,0 +1,12 @@
+package com.thebrownfoxx.neon.common.extension.flow
+
+import com.thebrownfoxx.outcome.Outcome
+import com.thebrownfoxx.outcome.Success
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.map
+
+fun <T> Flow<Outcome<T, *>>.filterSuccess(): Flow<T> {
+    return filterIsInstance<Success<T>>()
+        .map { it.value }
+}

--- a/server/application/src/main/kotlin/com/thebrownfoxx/neon/server/application/dependency/DefaultDependencies.kt
+++ b/server/application/src/main/kotlin/com/thebrownfoxx/neon/server/application/dependency/DefaultDependencies.kt
@@ -1,7 +1,7 @@
 package com.thebrownfoxx.neon.server.application.dependency
 
-import com.thebrownfoxx.neon.common.PrintLogger
 import com.thebrownfoxx.neon.common.hash.MultiplatformHasher
+import com.thebrownfoxx.neon.common.logError
 import com.thebrownfoxx.neon.common.type.Url
 import com.thebrownfoxx.neon.common.type.id.MemberId
 import com.thebrownfoxx.neon.server.application.environment.DotEnvironment
@@ -91,8 +91,6 @@ class DefaultDependencies : Dependencies {
         groupMemberRepository,
     )
 
-    override val logger = PrintLogger
-
     init {
         runBlocking {
             generateInitialServiceData().integrate(
@@ -104,8 +102,7 @@ class DefaultDependencies : Dependencies {
                 passwordRepository,
                 messageRepository,
                 hasher,
-                logger,
-            ).onFailure { logger.logError(it) }
+            ).onFailure { logError() }
         }
     }
 }

--- a/server/application/src/main/kotlin/com/thebrownfoxx/neon/server/application/dependency/Dependencies.kt
+++ b/server/application/src/main/kotlin/com/thebrownfoxx/neon/server/application/dependency/Dependencies.kt
@@ -1,6 +1,5 @@
 package com.thebrownfoxx.neon.server.application.dependency
 
-import com.thebrownfoxx.neon.common.Logger
 import com.thebrownfoxx.neon.server.application.environment.ServerEnvironment
 import com.thebrownfoxx.neon.server.application.websocket.WebSocketManager
 import com.thebrownfoxx.neon.server.service.Authenticator
@@ -19,5 +18,4 @@ interface Dependencies {
     val groupManager: GroupManager
     val memberManager: MemberManager
     val messenger: Messenger
-    val logger: Logger
 }

--- a/server/application/src/main/kotlin/com/thebrownfoxx/neon/server/application/routing/WebSocketConnectionRoute.kt
+++ b/server/application/src/main/kotlin/com/thebrownfoxx/neon/server/application/routing/WebSocketConnectionRoute.kt
@@ -2,6 +2,7 @@ package com.thebrownfoxx.neon.server.application.routing
 
 import com.thebrownfoxx.neon.common.data.websocket.send
 import com.thebrownfoxx.neon.common.extension.loop
+import com.thebrownfoxx.neon.common.logInfo
 import com.thebrownfoxx.neon.common.type.id.MemberId
 import com.thebrownfoxx.neon.common.type.id.Uuid
 import com.thebrownfoxx.neon.server.application.dependency.DependencyProvider
@@ -32,7 +33,6 @@ fun Route.webSocketConnectionRoute() {
                 val session = MutableKtorServerWebSocketSession(
                     session = this,
                     memberId = memberId,
-                    logger = logger,
                 )
                 webSocketManager.addSession(session)
                 session.send(WebSocketConnectionResponse.ConnectionSuccessful())
@@ -48,7 +48,7 @@ fun Route.webSocketConnectionRoute() {
                     runFailing { incoming.receive() }
                         .onSuccess { session.emitFrame(it) }
                         .onFailure {
-                            logger.logInfo("Closed WebSocketSession ${session.id}")
+                            logInfo("Closed WebSocketSession ${session.id}")
                             breakLoop()
                         }
                 }

--- a/server/application/src/main/kotlin/com/thebrownfoxx/neon/server/application/websocket/KtorServerWebSocketSession.kt
+++ b/server/application/src/main/kotlin/com/thebrownfoxx/neon/server/application/websocket/KtorServerWebSocketSession.kt
@@ -1,11 +1,11 @@
 package com.thebrownfoxx.neon.server.application.websocket
 
-import com.thebrownfoxx.neon.common.Logger
 import com.thebrownfoxx.neon.common.data.websocket.WebSocketSession
 import com.thebrownfoxx.neon.common.data.websocket.WebSocketSession.SendError
 import com.thebrownfoxx.neon.common.data.websocket.ktor.KtorSerializedWebSocketMessage
 import com.thebrownfoxx.neon.common.data.websocket.ktor.toKtorTypeInfo
 import com.thebrownfoxx.neon.common.data.websocket.model.SerializedWebSocketMessage
+import com.thebrownfoxx.neon.common.logInfo
 import com.thebrownfoxx.neon.common.type.Type
 import com.thebrownfoxx.neon.common.type.id.Id
 import com.thebrownfoxx.neon.common.type.id.MemberId
@@ -30,13 +30,12 @@ abstract class KtorServerWebSocketSession(
     val id: WebSocketSessionId = WebSocketSessionId(),
     val memberId: MemberId,
     private val session: WebSocketServerSession,
-    private val logger: Logger,
 ) : WebSocketSession {
     override suspend fun send(message: Any?, type: Type): UnitOutcome<SendError> {
         return runFailing {
             withContext(Dispatchers.IO) {
                 session.sendSerialized(data = message, typeInfo = type.toKtorTypeInfo())
-                logger.logInfo("Sent: $message")
+                logInfo("Sent: $message")
             }
         }.mapError { SendError }
     }
@@ -51,8 +50,7 @@ class MutableKtorServerWebSocketSession(
     id: WebSocketSessionId = WebSocketSessionId(),
     memberId: MemberId,
     private val session: WebSocketServerSession,
-    private val logger: Logger,
-) : KtorServerWebSocketSession(id, memberId, session, logger) {
+) : KtorServerWebSocketSession(id, memberId, session) {
     private val _closed = MutableStateFlow(false)
     override val closed = _closed.asStateFlow()
 
@@ -62,7 +60,7 @@ class MutableKtorServerWebSocketSession(
     suspend fun emitFrame(frame: Frame) {
         val message = KtorSerializedWebSocketMessage(converter = session.converter!!, frame = frame)
         val serializedValue = message.serializedValue.getOrElse { "<unknown message>" }
-        logger.logInfo("Received: $serializedValue")
+        logInfo("Received: $serializedValue")
         _incomingMessages.emit(message)
     }
 

--- a/server/repository/src/commonMain/kotlin/com/thebrownfoxx/neon/server/repository/data/IntegrateServiceData.kt
+++ b/server/repository/src/commonMain/kotlin/com/thebrownfoxx/neon/server/repository/data/IntegrateServiceData.kt
@@ -1,8 +1,8 @@
 package com.thebrownfoxx.neon.server.repository.data
 
-import com.thebrownfoxx.neon.common.Logger
 import com.thebrownfoxx.neon.common.data.transaction.transaction
 import com.thebrownfoxx.neon.common.hash.Hasher
+import com.thebrownfoxx.neon.common.logInfo
 import com.thebrownfoxx.neon.server.repository.ConfigurationRepository
 import com.thebrownfoxx.neon.server.repository.GroupMemberRepository
 import com.thebrownfoxx.neon.server.repository.GroupRepository
@@ -26,12 +26,11 @@ suspend fun ServiceData.integrate(
     passwordRepository: PasswordRepository,
     messageRepository: MessageRepository,
     hasher: Hasher,
-    logger: Logger,
 ): UnitOutcome<Any> {
     if (configurationRepository.getInitialized().getOrElse { return Failure(it) })
         return UnitSuccess
 
-    logger.logInfo("Integrating $this")
+    logInfo("Integrating $this")
     return transaction {
         for (groupRecord in groupRecords) {
             val (group, memberIds) = groupRecord


### PR DESCRIPTION
Simplified WebSocketSession, especially on the client side
- Depracated `AlwaysActiveWebSocketSession` in favor of `WebSocketSessionProvider`
- Introduced `AutoRetryWebSocketSession/Requester` in favor of `AlwaysActiveWebSocketSession`
- Added `LoggerProvider` to avoid having to pass around `Logger`
- Made the logging of `WebSocketSession`s more consistent

Closes #21